### PR TITLE
Add Webhook Signature validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,23 +78,18 @@ Or to look up a company:
           ],
           ...
 
-## Secure Webhooks
+## Webhooks
 
-Use the `.valid?` function to verify the webhook is from trusted party:
+For rack apps use the `WebhookResponse` module to wrap deserialization and verify the webhook is from trusted party:
 
 ``` ruby
 post '/v1/webhooks/apihub' do
-  request.body.rewind
-  payload_body = request.body.read
-
-  unless Clearbit::WebhookSignature.valid?(signature, payload_body)
-    halt 500, "Abort mission. Signatures didn't match!"
-  end
+  webhook = Clearbit::WebhookResponse.new(request)
+  webhook.type #= 'person'
+  webhook.body.name.given_name #=> 'Alex'
 
   # ...
-end
-
-def signature
-  request.env['HTTP_X_REQUEST_SIGNATURE']
+rescue Clearbit::Errors::InvalidWebhookSignature => e
+  # ...
 end
 ```

--- a/README.md
+++ b/README.md
@@ -77,3 +77,24 @@ Or to look up a company:
             "Garrett Camp"
           ],
           ...
+
+## Secure Webhooks
+
+Use the `.valid?` function to verify the webhook is from trusted party:
+
+``` ruby
+post '/v1/webhooks/apihub' do
+  request.body.rewind
+  payload_body = request.body.read
+
+  unless Clearbit::WebhookSignature.valid?(signature, payload_body)
+    halt 500, "Abort mission. Signatures didn't match!"
+  end
+
+  # ...
+end
+
+def signature
+  request.env['HTTP_X_REQUEST_SIGNATURE']
+end
+```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For rack apps use the `WebhookResponse` module to wrap deserialization and verif
 ``` ruby
 post '/v1/webhooks/apihub' do
   webhook = Clearbit::WebhookResponse.new(request)
-  webhook.type #= 'person'
+  webhook.type #=> 'person'
   webhook.body.name.given_name #=> 'Alex'
 
   # ...

--- a/apihub.gemspec
+++ b/apihub.gemspec
@@ -24,6 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_dependency 'mash'
   spec.add_dependency 'nestful', '~> 1.0.7'
 end

--- a/apihub.gemspec
+++ b/apihub.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  spec.add_dependency 'mash'
   spec.add_dependency 'nestful', '~> 1.0.7'
 end

--- a/apihub.gemspec
+++ b/apihub.gemspec
@@ -19,7 +19,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'climate_control'
   spec.add_development_dependency 'net-http-spy'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
   spec.add_dependency 'nestful', '~> 1.0.7'
 end

--- a/lib/clearbit.rb
+++ b/lib/clearbit.rb
@@ -18,6 +18,7 @@ module Clearbit
   autoload :Resource, 'clearbit/resource'
   autoload :Streaming, 'clearbit/streaming'
   autoload :Watchlist, 'clearbit/watchlist'
+  autoload :WebhookSignature, 'clearbit/webhook_signature'
 
   if clearbit_key = ENV['CLEARBIT_KEY']
     Clearbit.key = clearbit_key

--- a/lib/clearbit.rb
+++ b/lib/clearbit.rb
@@ -18,7 +18,12 @@ module Clearbit
   autoload :Resource, 'clearbit/resource'
   autoload :Streaming, 'clearbit/streaming'
   autoload :Watchlist, 'clearbit/watchlist'
+  autoload :WebhookResponse, 'clearbit/webhook_response'
   autoload :WebhookSignature, 'clearbit/webhook_signature'
+
+  module Errors
+    autoload :InvalidWebhookSignature, 'clearbit/errors/invalid_webhook_signature'
+  end
 
   if clearbit_key = ENV['CLEARBIT_KEY']
     Clearbit.key = clearbit_key

--- a/lib/clearbit/errors/invalid_webhook_signature.rb
+++ b/lib/clearbit/errors/invalid_webhook_signature.rb
@@ -1,0 +1,10 @@
+module Clearbit
+  module Errors
+    # Raised when the Webhook Request Signature doesn't validate.
+    class InvalidWebhookSignature < StandardError
+      def to_s
+        'Clearbit Webhook Request Signature was invalid.'
+      end
+    end
+  end
+end

--- a/lib/clearbit/webhook_response.rb
+++ b/lib/clearbit/webhook_response.rb
@@ -7,7 +7,7 @@ module Clearbit
 
       WebhookSignature.validate!(request_signature, request_body)
 
-      Mash.from_json(request_body)
+      Mash.new(JSON.parse(request_body))
     end
   end
 end

--- a/lib/clearbit/webhook_response.rb
+++ b/lib/clearbit/webhook_response.rb
@@ -1,0 +1,13 @@
+module Clearbit
+  module WebhookResponse
+    def initialize(request)
+      request.body.rewind
+      request_signature = request.env['HTTP_X_REQUEST_SIGNATURE']
+      request_body = request.body.read
+
+      WebhookSignature.validate!(request_signature, request_body)
+
+      Mash.from_json(request_body)
+    end
+  end
+end

--- a/lib/clearbit/webhook_signature.rb
+++ b/lib/clearbit/webhook_signature.rb
@@ -1,0 +1,15 @@
+require 'rack/utils'
+require 'openssl'
+
+module Clearbit
+  module WebhookSignature
+    def self.valid?(request_signature, webhook_body)
+      signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), clearbit_key, webhook_body)
+      Rack::Utils.secure_compare(signature, request_signature)
+    end
+
+    def self.clearbit_key
+      ENV['CLEARBIT_KEY'] || raise('Clearbit config error: Please make sure CLEARBIT_KEY env var is set.')
+    end
+  end
+end

--- a/lib/clearbit/webhook_signature.rb
+++ b/lib/clearbit/webhook_signature.rb
@@ -3,9 +3,14 @@ require 'openssl'
 
 module Clearbit
   module WebhookSignature
-    def self.valid?(request_signature, webhook_body)
+    def self.validate!(request_signature, webhook_body)
       signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), clearbit_key, webhook_body)
-      Rack::Utils.secure_compare(signature, request_signature)
+
+      if Rack::Utils.secure_compare(signature, request_signature)
+        true
+      else
+        raise Errors::InvalidWebhookSignature
+      end
     end
 
     def self.clearbit_key

--- a/spec/lib/clearbit/webhook_signature_spec.rb
+++ b/spec/lib/clearbit/webhook_signature_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Clearbit::WebhookSignature, '.valid?' do
+  context 'valid HMAC signature' do
+    it 'returns true' do
+      signature = generate_signature('A-OK')
+
+      result = Clearbit::WebhookSignature.valid?(signature, 'A-OK')
+
+      expect(result).to eq true
+    end
+  end
+
+  context 'invalid HMAC signature' do
+    it 'returns false' do
+      signature = generate_signature('A-OK')
+
+      result = Clearbit::WebhookSignature.valid?(signature, 'TAMPERED_WITH_BODY_BEWARE!')
+
+      expect(result).to eq false
+    end
+  end
+
+  around do |example|
+    ClimateControl.modify CLEARBIT_KEY: 'clearbit_key' do
+      example.run
+    end
+  end
+
+  def generate_signature(webhook_body)
+    'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha1'), 'clearbit_key', webhook_body)
+  end
+end

--- a/spec/lib/clearbit/webhook_signature_spec.rb
+++ b/spec/lib/clearbit/webhook_signature_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe Clearbit::WebhookSignature, '.valid?' do
-  context 'valid HMAC signature' do
+describe Clearbit::WebhookSignature, '.validate!' do
+  context 'valid signature' do
     it 'returns true' do
       signature = generate_signature('A-OK')
 
-      result = Clearbit::WebhookSignature.valid?(signature, 'A-OK')
+      result = Clearbit::WebhookSignature.validate!(signature, 'A-OK')
 
       expect(result).to eq true
     end
   end
 
-  context 'invalid HMAC signature' do
+  context 'invalid signature' do
     it 'returns false' do
       signature = generate_signature('A-OK')
 
-      result = Clearbit::WebhookSignature.valid?(signature, 'TAMPERED_WITH_BODY_BEWARE!')
-
-      expect(result).to eq false
+      expect {
+        Clearbit::WebhookSignature.validate!(signature, 'TAMPERED_WITH_BODY_BEWARE!')
+      }.to raise_error(Clearbit::Errors::InvalidWebhookSignature)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__))
+
+# External
+require 'rubygems'
+require 'rspec'
+require 'pry'
+require 'climate_control'
+
+# Library
+require 'clearbit'


### PR DESCRIPTION
To verify the webhooks are indeed coming from Clearbit we recommend the
end user verifies all request bodies by verifying the HMAC signature.

* Add WebhookSignature helper module
* Set up RSpec test suite
* Update README with validation example