### PR TITLE
Logo API URL builder

### DIFF
--- a/examples/logo.rb
+++ b/examples/logo.rb
@@ -1,0 +1,4 @@
+require 'clearbit'
+require 'pp'
+
+pp Clearbit::Logo.url(domain: 'clearbit.com')

--- a/lib/clearbit.rb
+++ b/lib/clearbit.rb
@@ -20,6 +20,7 @@ module Clearbit
 
   autoload :Base, 'clearbit/base'
   autoload :Company, 'clearbit/company'
+  autoload :Logo, 'clearbit/logo'
   autoload :Mash, 'clearbit/mash'
   autoload :Person, 'clearbit/person'
   autoload :PersonCompany, 'clearbit/person_company'

--- a/lib/clearbit/logo.rb
+++ b/lib/clearbit/logo.rb
@@ -1,0 +1,39 @@
+module Clearbit
+  class Logo
+    ENDPOINT = 'https://logo.clearbit.com'
+
+    def self.url(values)
+      params = values.delete(params) || {}
+
+      if size = values.delete(:size)
+        params.merge!(size: size)
+      end
+
+      if format = values.delete(:format)
+        params.merge!(format: format)
+      end
+
+      if greyscale = values.delete(:greyscale)
+        params.merge!(greyscale: greyscale)
+      end
+
+      encoded_params = URI.encode_www_form(params)
+
+      if domain = values.delete(:domain)
+        raise ArgumentError, 'Invalid domain' unless domain =~ /^([a-z0-9]+)*\.[a-z]{2,5}$/
+        if encoded_params.empty?
+          "#{ENDPOINT}/#{domain}"
+        else
+          "#{ENDPOINT}/#{domain}?#{encoded_params}"
+        end
+      else
+        raise ArgumentError, 'Invalid values'
+      end
+
+    end
+
+    class << self
+      alias_method :[], :url
+    end
+  end
+end


### PR DESCRIPTION
This will allow users of the gem to have a clean way of construction the url to fetch image using Clearbit Logo API.

Return a URL of the clearbit logo API path along with it’s params.

Clearbit::Logo.url(domain: 'clearbit.com', size: '200x200)
=> 'https://logo.clearbit.com/clearbit.com?&size=200x200'