### PR TITLE
Broaden regex for domain validation

### DIFF
--- a/lib/clearbit/logo.rb
+++ b/lib/clearbit/logo.rb
@@ -20,7 +20,7 @@ module Clearbit
       encoded_params = URI.encode_www_form(params)
 
       if domain = values.delete(:domain)
-        raise ArgumentError, 'Invalid domain' unless domain =~ /^([a-z0-9]+)*\.[a-z]{2,5}$/
+        raise ArgumentError, 'Invalid domain' unless domain =~ /^[a-z0-9\-]+([\.]{1}[a-z0-9\-]+)*\.[a-z]{2,5}$/
         if encoded_params.empty?
           "#{ENDPOINT}/#{domain}"
         else

--- a/spec/lib/clearbit/logo_spec.rb
+++ b/spec/lib/clearbit/logo_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Clearbit::Logo do
+  context 'domain validation' do
+
+    def check_valid_domain(domain)
+      expect {
+        Clearbit::Logo.url({
+          domain: domain
+        })
+      }.not_to raise_error
+    end
+
+    def check_invalid_domain(domain)
+      expect {
+        Clearbit::Logo.url({
+          domain: domain
+        })
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'passes for simple domains' do
+      check_valid_domain('clearbit.com')
+    end
+
+    it 'passes for dashed domains' do
+      check_valid_domain('clear-bit.com')
+      check_valid_domain('clear--bit.com.uk')
+    end
+
+    it 'passes for multi-dot TLDs' do
+      check_valid_domain('bbc.co.uk')
+      check_valid_domain('clear-bit.co.uk')
+    end
+
+    it 'fails for invalid urls' do
+      check_invalid_domain('clearbit.verylongtld')
+    end
+  end
+end


### PR DESCRIPTION
Change the regex used in the Logo API url builder. I'm open to discuss other regex matchers, since matching domains can get pretty complex.

Also added some tests to check behavior.