### PR TITLE
Fix autocomplete class

### DIFF
--- a/lib/clearbit/autocomplete.rb
+++ b/lib/clearbit/autocomplete.rb
@@ -1,14 +1,12 @@
 module Clearbit
-  module Autocomplete
-    class Company < Base
-      endpoint 'https://autocomplete.clearbit.com'
-      path '/v1'
+  class Autocomplete < Base
+    endpoint 'https://autocomplete.clearbit.com'
+    path '/v1'
 
-      def self.suggest(query)
-        response = get 'companies/suggest', query: query
+    def self.suggest(query)
+      response = get 'companies/suggest', query: query
 
-        self.new(response)
-      end
+      self.new(response)
     end
   end
 end


### PR DESCRIPTION
The autocomplete class was broken, I was getting `NameError: uninitialized constant Clearbit::Autocomplete` errors. When I looked into the source, I found the class was incorrect, it was:

```ruby
# lib/clearbit/autocomplete.rb
module Clearbit
  module Autocomplete
    class Company < Base
    end
  end
end
```

I removed the `Autocomplete` module and renamed the class to `Autocomplete`, now it looks like:

```ruby
# lib/clearbit/autocomplete.rb
module Clearbit
  class Autocomplete < Base
  end
end
```

It works now you can call:

```ruby
Clearbit::Autocomplete.suggest("goog")
```