### PR TITLE
Bump version to include Autocomplete API

### DIFF
--- a/lib/clearbit/version.rb
+++ b/lib/clearbit/version.rb
@@ -1,3 +1,3 @@
 module Clearbit
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
Noticed that the Autocomplete API [was exposed through the gem in October](https://github.com/clearbit/clearbit-ruby/commit/d2a87e38eebd30b29801e1a3779d42400e85f7dd), but the version hasn't been bumped to enable it. Not sure if that's the intended behavior, but it's a nice addition.