### PR TITLE
Remove the Bundler version restriction.

### DIFF
--- a/clearbit.gemspec
+++ b/clearbit.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'json', ['~> 1.7'] if RUBY_VERSION < '1.9'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'net-http-spy'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Resolves 4 security alerts.

- Critical
  - https://github.com/clearbit/clearbit-ruby/security/dependabot/4
- High
  - https://github.com/clearbit/clearbit-ruby/security/dependabot/1
  - https://github.com/clearbit/clearbit-ruby/security/dependabot/2
- Moderate
  - https://github.com/clearbit/clearbit-ruby/security/dependabot/3